### PR TITLE
more hashes for Sierra (including beta 5)

### DIFF
--- a/CoreDisplay-patcher.command
+++ b/CoreDisplay-patcher.command
@@ -20,12 +20,16 @@ oToolCoreDisplayCurrent="$(otool -t $CoreDisplayLocation |tail -n +2 |md5 -q)"
 oToolCoreDisplayUnpatched=(
   49cd8062ed1c8f610b71e9a3231cf804 '10.12 16A254g' 1
   8e1030235b90d6ab0644bd7a1b6f9cdb '10.12 16A284a' 1
+  f4c6e84ffa97e06624e5504edd87bf7d '10.12 16A284a' 1 # I don't know why these two are different
+  4cba52b41ceee7bc658020c9e58780a3 '10.12 16A294a' 1
 )
 
 # md5 checksum of '(__DATA,__data)' section exported by otool from patched CoreDisplays
 oToolCoreDisplayPatched=(
   4e469fbf1c36d96fc25fb931c6670649 '10.12 16A254g'
   b6ee4943c2fce505faceb568e1c8f4b1 '10.12 16A284a'
+  82f97933a3ae90d47054316fa8259f6c '10.12 16A284a'
+  1371f71ca7949cfbe01ede8e8b52e61d '10.12 16A294a'
 )
 
 function makeExit {


### PR DESCRIPTION
Add a couple more patched/unpatched hashes for Mac OS X Sierra 10.12
betas. One for beta 5 and one for the previous release.

The patch seems to be fine, I can use 1440p on my monitor and not be forced into 1080p, but with HDMI connected to the HD3000 in my mid-2011 mac mini server, I was getting white flashes on the bottom of the screen every few seconds. And sometimes the screen would turn off, but this happened rarely. Also when the display was sleeping, it would periodically lose signal and reconnect, this happened every couple of seconds so I had to turn off the monitor. I don't know enough about OS X to debug this, or even know where to start.

With my thunderbolt GPU, there are no screen flashes or power issues, however I have some screen corruption in things like the menubar and spotlight, but this is likely not related to this patch. Description and screenshots [here](https://github.com/goalque/automate-eGPU/issues/31).