### PR TITLE
Changed "status" action

### DIFF
--- a/CoreDisplay-patcher.command
+++ b/CoreDisplay-patcher.command
@@ -83,7 +83,10 @@ function testSIP {
       askExit
     elif [[ "$(csrutil status | head -n 1)" == *"status: enabled"* ]]; then
       printf "SIP is enabled, this script will only work if SIP is disabled\n"
-      makeExit
+      if [[ -z $1 ]]; then
+        makeExit
+      fi
+      
     elif [[ "$(csrutil status | head -n 1)" == *"status: disabled"* ]]; then
       printf "SIP looks to be disabled, all good!\n"
     fi
@@ -160,7 +163,12 @@ function testCoreDisplayPatch {
 }
 
 function test {
-  testSIP
+  if [[ ! -z $1 && $1 == "status" ]]; then
+    testSIP "Don't Exit"  # Just checking patch status, can do it even if SIP is enabled
+  else
+    testSIP
+  fi
+  
   printf "\n"
   nothingWasFound=true;
   for ((i=0; i < ${#CoreDisplayUnpatched[@]}; i+=3)); do
@@ -234,7 +242,7 @@ function options {
     fi
     CoreDisplayUnpatch
   elif [[ $1 == 'test' ]] || [[ $1 == 'status' ]]; then
-    test
+    test 'status'
     exit
   elif [[ $1 == 'md5' ]]; then
     CoreDisplayPrintAllMD5


### PR DESCRIPTION
Continue to check patch status even if SIP is enabled (don't exit in testSIP).

Reasoning: more info is better. Also I'm writing a script that needs to know SIP and patch status at the same time.