### PR TITLE
Fixing after OSX 10.14.6 update (build version 18G1012, possible fix for 18G95 also!)

### DIFF
--- a/CoreDisplay-patcher.command
+++ b/CoreDisplay-patcher.command
@@ -35,6 +35,8 @@ oToolCoreDisplayUnpatched=(
   714a9e14ccc64b0cf4bef2f083087d8e '10.14.2 (18C54)' 5
   814fe7a8695f6583d821b5665f6df71a '10.14.5 (18F132)' 5
   105051509e563ba96f190ed78a52feb9 '10.14.6 (18G84)' 5
+  105051509e563ba96f190ed78a52feb9 '10.14.6 (18G95)' 5
+  105051509e563ba96f190ed78a52feb9 '10.14.6 (18G1012)' 5  
 )
 
 # md5 checksum of '(__DATA,__data)' section exported by otool from patched CoreDisplays
@@ -56,6 +58,7 @@ oToolCoreDisplayPatched=(
   2d71736504e14882b2eb5e994859ec09 '10.14.2 (18C54)'
   9581c3d50658882e79325bcf5f510245 '10.14.5 (18F132)'
   d4f2aca73c7915c639dbe9a7b9cf5ecd '10.14.6 (18G84)'
+  450241a06a439cd226c9e9cf5cf634d7 '10.14.6 (18G95 and 18G1012)'
 )
 
 function makeExit {


### PR DESCRIPTION
I got patch running on OSX 10.14.6 (buildVersion 18G84). After a system update (I don't know what installed) patch got broken, but still I saw OSX as 10.14.6 (no minor change!). After checking, the build version was different.

Just ran (again) the command for patching (chmod +x CoreDisplay-patcher.command && ./CoreDisplay-patcher.command) and updated correspondingly the md5 included in this commit. 

In my case, I just had to reboot (after repatching), re-run SwitchResX, and select the appropriate resolution (2560X1080) for my monitor (LG UM58).